### PR TITLE
Revert deprecation warning fix, Fixes #8

### DIFF
--- a/code/RegexScanner.ml
+++ b/code/RegexScanner.ml
@@ -16,7 +16,7 @@ let make_line_reader fname =
       None
     else
       try
-        Some (Scanf.bscanf (Scanf.Scanning.from_channel in_channel) "%[^\r\n]\n" (fun x -> x))
+        Some (Scanf.fscanf in_channel "%[^\r\n]\n" (fun x -> x))
       with
         End_of_file ->
           close_in_noerr in_channel;

--- a/code/RuleScanner.ml
+++ b/code/RuleScanner.ml
@@ -24,7 +24,7 @@ let make_line_reader fname =
       None
     else
       try
-        Some (Scanf.bscanf (Scanf.Scanning.from_channel in_channel) "%[^\r\n]\n" (fun x -> x))
+        Some (Scanf.fscanf in_channel "%[^\r\n]\n" (fun x -> x))
       with
         End_of_file ->
           let _ = close_in_noerr in_channel in


### PR DESCRIPTION
The deprecation warning says:

```
File "RuleScanner.ml", line 27, characters 14-26:
27 |         Some (Scanf.fscanf in_channel "%[^\r\n]\n" (fun x -> x))
                   ^^^^^^^^^^^^
Alert deprecated: Stdlib.Scanf.fscanf
Use Scanning.from_channel then Scanf.bscanf.
```

But clearly I'm missing the difference between what they suggest and what I
tried. Reverting this fixes it, at the expense of reintroducing the compile
warning.